### PR TITLE
Setting .NET roll forward policy

### DIFF
--- a/MsiSneakAttack/Msi.cs
+++ b/MsiSneakAttack/Msi.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace MsiSneakAttack
 {

--- a/MsiSneakAttack/MsiSneakAttack.csproj
+++ b/MsiSneakAttack/MsiSneakAttack.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This project targets .NET 5.0, and since there's no roll forward policy set it won't run if you only have the .NET 6/7 runtime installed.  I'm setting the roll forward policy to latest major, meaning it will run using a newer .NET runtime, like 6/7/8/etc.  Here's more info on roll forward policies: https://andrewlock.net/exploring-the-new-rollforward-and-allowprerelease-settings-in-global-json/

Also fixing a duplicate using warning